### PR TITLE
FIX: update pygraphviz_layout function calls

### DIFF
--- a/graphcanvas/graph_container.py
+++ b/graphcanvas/graph_container.py
@@ -37,7 +37,9 @@ class GraphContainer(Container):
                 component.y = self.height - max_y + layout[component._key][1]
 
         if self.style == 'tree':
-            layout = networkx.pygraphviz_layout(self.graph, prog='dot')
+            layout = networkx.drawing.nx_agraph.pygraphviz_layout(
+                self.graph, prog='dot'
+            )
 
             # resize the bounds to fit the graph
             depths = [v[1] for v in layout.values()]
@@ -65,8 +67,11 @@ class GraphContainer(Container):
             for component in self.components:
                 component.y = self.height * (1 + layout[component._key][0])/2
                 component.x = self.width * (1 + layout[component._key][1])/2
+
         elif self.style == 'circular':
-            layout = networkx.pygraphviz_layout(self.graph, prog='twopi')
+            layout = networkx.drawing.nx_agraph.pygraphviz_layout(
+                self.graph, prog='twopi'
+            )
 
             # resize the bounds to fit the graph
             radius = numpy.log2(len(layout))


### PR DESCRIPTION
It seems like the current dependencies for `graphcanvas` require `networkx-1.11` but it is using an older module location for the `pygraphviz_layout` function. As such, a clean installation of the latest `graphcanvas` release fails when attempting to use any of the pygraphviz layouts. This PR updates those, but it could also be easily folded into #2.