### PR TITLE
FIX: allow plotting of single-node directed graphs

### DIFF
--- a/graphcanvas/graph_container.py
+++ b/graphcanvas/graph_container.py
@@ -163,23 +163,25 @@ class GraphContainer(Container):
         if self.graph.is_directed():
             a = 0.707106781   # sqrt(2)/2
             vec = line_ends - line_starts
-            if len(vec) > 0:
-                unit_vec = vec / numpy.sqrt(vec[:,0] ** 2 + vec[:,1] ** 2)[:, numpy.newaxis]
+            if len(vec) == 0:
+                return
 
-                with gc:
-                    gc.set_fill_color((1,1,1,0))
+            unit_vec = vec / numpy.sqrt(vec[:,0] ** 2 + vec[:,1] ** 2)[:, numpy.newaxis]
 
-                    # Draw the left arrowhead (for an arrow pointing straight up)
-                    arrow_ends = line_ends - numpy.array(unit_vec*numpy.matrix([[a, a], [-a, a]])) * 10
-                    gc.begin_path()
-                    gc.line_set(line_ends, arrow_ends)
-                    gc.stroke_path()
+            with gc:
+                gc.set_fill_color((1,1,1,0))
 
-                    # Draw the right arrowhead (for an arrow pointing straight up)
-                    arrow_ends = line_ends - numpy.array(unit_vec*numpy.matrix([[a, -a], [a, a]])) * 10
-                    gc.begin_path()
-                    gc.line_set(line_ends, arrow_ends)
-                    gc.stroke_path()
+                # Draw the left arrowhead (for an arrow pointing straight up)
+                arrow_ends = line_ends - numpy.array(unit_vec*numpy.matrix([[a, a], [-a, a]])) * 10
+                gc.begin_path()
+                gc.line_set(line_ends, arrow_ends)
+                gc.stroke_path()
+
+                # Draw the right arrowhead (for an arrow pointing straight up)
+                arrow_ends = line_ends - numpy.array(unit_vec*numpy.matrix([[a, -a], [a, a]])) * 10
+                gc.begin_path()
+                gc.line_set(line_ends, arrow_ends)
+                gc.stroke_path()
 
     def _graph_changed(self, new):
         self._graph_layout_needed = True

--- a/graphcanvas/graph_container.py
+++ b/graphcanvas/graph_container.py
@@ -219,7 +219,6 @@ class GraphContainer(Container):
         line_ctrl1s = numpy.array(line_ctrl1s)
         line_ctrl2s = numpy.array(line_ctrl2s)
 
-
         if self.graph.is_directed():
             with gc:
                 gc.set_fill_color((.5,.5,.5,1))

--- a/graphcanvas/graph_container.py
+++ b/graphcanvas/graph_container.py
@@ -163,22 +163,23 @@ class GraphContainer(Container):
         if self.graph.is_directed():
             a = 0.707106781   # sqrt(2)/2
             vec = line_ends - line_starts
-            unit_vec = vec / numpy.sqrt(vec[:,0] ** 2 + vec[:,1] ** 2)[:, numpy.newaxis]
+            if len(vec) > 0:
+                unit_vec = vec / numpy.sqrt(vec[:,0] ** 2 + vec[:,1] ** 2)[:, numpy.newaxis]
 
-            with gc:
-                gc.set_fill_color((1,1,1,0))
+                with gc:
+                    gc.set_fill_color((1,1,1,0))
 
-                # Draw the left arrowhead (for an arrow pointing straight up)
-                arrow_ends = line_ends - numpy.array(unit_vec*numpy.matrix([[a, a], [-a, a]])) * 10
-                gc.begin_path()
-                gc.line_set(line_ends, arrow_ends)
-                gc.stroke_path()
+                    # Draw the left arrowhead (for an arrow pointing straight up)
+                    arrow_ends = line_ends - numpy.array(unit_vec*numpy.matrix([[a, a], [-a, a]])) * 10
+                    gc.begin_path()
+                    gc.line_set(line_ends, arrow_ends)
+                    gc.stroke_path()
 
-                # Draw the right arrowhead (for an arrow pointing straight up)
-                arrow_ends = line_ends - numpy.array(unit_vec*numpy.matrix([[a, -a], [a, a]])) * 10
-                gc.begin_path()
-                gc.line_set(line_ends, arrow_ends)
-                gc.stroke_path()
+                    # Draw the right arrowhead (for an arrow pointing straight up)
+                    arrow_ends = line_ends - numpy.array(unit_vec*numpy.matrix([[a, -a], [a, a]])) * 10
+                    gc.begin_path()
+                    gc.line_set(line_ends, arrow_ends)
+                    gc.stroke_path()
 
     def _graph_changed(self, new):
         self._graph_layout_needed = True

--- a/graphcanvas/tests/test_graph_container.py
+++ b/graphcanvas/tests/test_graph_container.py
@@ -142,6 +142,14 @@ class TestGraphContainer(KivaTestAssistant, unittest.TestCase):
             GraphNodeComponent(container=container, value=node)
         self.assertPathsAreCreated(container)
 
+    def test_draw_single_node(self):
+        g = networkx.DiGraph()
+        g.add_node('a')
+        container = GraphContainer(graph=g)
+        for node in g.nodes():
+            GraphNodeComponent(container=container, value=node)
+        self.assertPathsAreCreated(container)
+
     def test_weighted(self):
         g = networkx.Graph()
         g.add_edge('a','b',weight=0.6)


### PR DESCRIPTION
Closes #4.

This skips the drawing of arrowheads on the edges of a directed graph where there are no edges (e.g. where there is only a single node).

Example behavior:
![graphcanvas_pr5](https://cloud.githubusercontent.com/assets/8642896/17790568/a4cc3afa-655c-11e6-940c-700e2a0f8176.png)
as opposed to the `IndexError` raised in `master`.
