### PR TITLE
Graph node drag tool

### DIFF
--- a/graphcanvas/graph_node_drag_tool.py
+++ b/graphcanvas/graph_node_drag_tool.py
@@ -15,7 +15,6 @@ class GraphNodeDragTool(ValueDragTool):
     def get_value(self):
         for node in self.component.components:
             if node.is_in(*self.original_screen_point):
-                print 'node found', node.label
                 return node
 
     def set_delta(self, value, delta_x, delta_y):

--- a/graphcanvas/graph_node_drag_tool.py
+++ b/graphcanvas/graph_node_drag_tool.py
@@ -1,0 +1,58 @@
+from enable.api import BaseTool, Pointer
+from traits.api import Either, Float, HasTraits
+
+from graph_node_component import GraphNodeComponent
+
+
+class GraphNodeDragTool(BaseTool):
+    """ Listens for a right click on a graph node and allows the user to
+        drag the selected node to a desired location. Edges are redrawn
+        live during the node's movement.
+    """
+
+    dragging_node = Either(GraphNodeComponent, None)
+
+    normal_pointer = Pointer("arrow")
+
+    moving_pointer = Pointer("hand")
+
+    offset_x = Float
+
+    offset_y = Float
+
+    def dragging_node_default(self):
+        return None
+
+    def normal_right_down(self, event):
+        for node in self.component.components:
+            if node.is_in(event.x, event.y):
+                self.dragging_node = node
+                self.event_state = "moving"
+                event.window.set_pointer(self.moving_pointer)
+                event.window.set_mouse_owner(self, event.net_transform())
+                self.offset_x = event.x - node.x
+                self.offset_y = event.y - node.y
+                event.handled = True
+        return
+
+    def moving_mouse_move(self, event):
+        self.dragging_node.position = [
+            event.x - self.offset_x, event.y - self.offset_y
+        ]
+        event.handled = True
+        self.dragging_node.request_redraw()
+        return
+
+    def moving_right_up(self, event):
+        self.event_state = "normal"
+        event.window.set_pointer(self.normal_pointer)
+        event.window.set_mouse_owner(None)
+        event.handled = True
+        self.dragging_node.request_redraw()
+        self.dragging_node = None
+        return
+
+    def moving_mouse_leave(self, event):
+        self.moving_right_up(event)
+        event.handled = True
+        return

--- a/graphcanvas/graph_node_drag_tool.py
+++ b/graphcanvas/graph_node_drag_tool.py
@@ -1,58 +1,29 @@
-from enable.api import BaseTool, Pointer
-from traits.api import Either, Float, HasTraits
+from enable.tools.api import ValueDragTool
 
-from graph_node_component import GraphNodeComponent
-
-
-class GraphNodeDragTool(BaseTool):
+class GraphNodeDragTool(ValueDragTool):
     """ Listens for a right click on a graph node and allows the user to
         drag the selected node to a desired location. Edges are redrawn
         live during the node's movement.
     """
 
-    dragging_node = Either(GraphNodeComponent, None)
+    drag_button = 'right'
 
-    normal_pointer = Pointer("arrow")
+    x_name = 'x'
 
-    moving_pointer = Pointer("hand")
+    y_name = 'y'
 
-    offset_x = Float
-
-    offset_y = Float
-
-    def dragging_node_default(self):
-        return None
-
-    def normal_right_down(self, event):
+    def get_value(self):
         for node in self.component.components:
-            if node.is_in(event.x, event.y):
-                self.dragging_node = node
-                self.event_state = "moving"
-                event.window.set_pointer(self.moving_pointer)
-                event.window.set_mouse_owner(self, event.net_transform())
-                self.offset_x = event.x - node.x
-                self.offset_y = event.y - node.y
-                event.handled = True
-        return
+            if node.is_in(*self.original_screen_point):
+                print 'node found', node.label
+                return node
 
-    def moving_mouse_move(self, event):
-        self.dragging_node.position = [
-            event.x - self.offset_x, event.y - self.offset_y
-        ]
-        event.handled = True
-        self.dragging_node.request_redraw()
-        return
+    def set_delta(self, value, delta_x, delta_y):
+        if value is not None:
+            value.x = self.original_screen_point[0] + delta_x
+            value.y = self.original_screen_point[1] + delta_y
+            value.request_redraw()
 
-    def moving_right_up(self, event):
-        self.event_state = "normal"
-        event.window.set_pointer(self.normal_pointer)
-        event.window.set_mouse_owner(None)
-        event.handled = True
-        self.dragging_node.request_redraw()
-        self.dragging_node = None
-        return
-
-    def moving_mouse_leave(self, event):
-        self.moving_right_up(event)
-        event.handled = True
-        return
+    def dragging(self, event):
+        event.window.set_pointer("hand")
+        super(GraphNodeDragTool, self).dragging(event)

--- a/graphcanvas/graph_view.py
+++ b/graphcanvas/graph_view.py
@@ -11,6 +11,8 @@ from graph_container import GraphContainer
 from graph_node_component import GraphNodeComponent
 from graph_node_selection_tool import GraphNodeSelectionTool
 from graph_node_hover_tool import GraphNodeHoverTool
+from graph_node_drag_tool import GraphNodeDragTool
+
 
 def graph_from_dict(d):
     """ Creates a NetworkX Graph from a dictionary
@@ -74,6 +76,7 @@ class GraphView(HasTraits):
         container.tools.append(GraphNodeSelectionTool(component=container))
         container.tools.append(GraphNodeHoverTool(component=container,
                                                   callback=self._on_hover))
+        container.tools.append(GraphNodeDragTool(component=container))
         return container
 
     def __container_default(self):

--- a/graphcanvas/tests/test_graph_node_drag_tool.py
+++ b/graphcanvas/tests/test_graph_node_drag_tool.py
@@ -1,0 +1,58 @@
+import unittest
+
+import mock
+import networkx
+
+from enable.api import AbstractWindow, BasicEvent
+from enable.testing import EnableTestAssistant
+from graphcanvas.graph_node_drag_tool import GraphNodeDragTool
+from graphcanvas.graph_container import GraphContainer
+from graphcanvas.graph_node_component import GraphNodeComponent
+
+
+class TestGraphNodeDragTool(EnableTestAssistant, unittest.TestCase):
+    def setUp(self):
+        g = networkx.DiGraph()
+        self.container = GraphContainer(graph=g)
+        self.tool = GraphNodeDragTool(component=self.container)
+        self.container.tools.append(self.tool)
+        self.container.components.append(
+            GraphNodeComponent(position=[0, 0])
+        )
+
+    def tearDown(self):
+        del self.container
+        del self.tool
+
+    def test_get_value(self):
+        # is in
+        self.tool.original_screen_point = (0, 0)
+        result = self.tool.get_value()
+        self.assertIsInstance(result, GraphNodeComponent)
+
+        # not in
+        self.tool.original_screen_point = (50, 50)
+        result = self.tool.get_value()
+        self.assertIsNone(result)
+
+    def test_set_delta(self):
+        delta_x = 10
+        delta_y = 10
+        self.tool.original_screen_point = (0, 0)
+        value = self.tool.get_value()
+        self.tool.set_delta(value, delta_x, delta_y)
+        self.assertEqual(value.x, delta_x)
+        self.assertEqual(value.y, delta_y)
+
+    def test_dragging(self):
+        mock_window = self.create_mock_window()
+        mock_window.get_pointer_position = mock.Mock(return_value=(0, 0))
+        self.tool.original_screen_point = (0, 0)
+        self.tool.original_data_point = (0, 0)
+        event = self.create_drag_event(window=mock_window)
+        self.tool.dragging(event)
+        mock_window.set_pointer.assert_called_once_with('hand')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/graphcanvas/tests/test_graph_view.py
+++ b/graphcanvas/tests/test_graph_view.py
@@ -44,7 +44,7 @@ class TestGraphView(unittest.TestCase):
     def test_canvas(self):
         self.assertIsInstance(self.view._canvas, DAGContainer)
         tools = self.view._canvas.tools
-        self.assertEquals(len(tools), 2)
+        self.assertEquals(len(tools), 3)
         self.assertIsInstance(tools[0], GraphNodeSelectionTool)
         self.assertIsInstance(tools[1], GraphNodeHoverTool)
 
@@ -87,7 +87,7 @@ class TestGraphView(unittest.TestCase):
     @mock.patch('sys.stdout', new_callable=StringIO)
     def test_on_hover(self, mock_stdout):
         view = GraphView(graph=graph_from_dict({'test':['test1']}))
-        hover_tool = view._canvas.tools[-1]
+        _, hover_tool, _ = view._canvas.tools
         hover_tool._last_xy = (0, 0)
         hover_tool.on_hover()
         self.assertEqual(mock_stdout.getvalue(),


### PR DESCRIPTION
This PR adds a simple node selection and dragging tool. On right click and drag (I could make the mouse button configurable as well), the node will move and the connecting edges will redraw live. I added the tool to the default tools list on the `GraphView` as well.

Here is a GIF of the tool in action:
![graphcanvas_drag_tool](https://cloud.githubusercontent.com/assets/8642896/17840366/c093ba4a-67ca-11e6-83b5-2143e5edbd4f.gif)

tl;dr Sometimes layouts aren't pretty, so adjust I made the layout interactive.
