### PR TITLE
🛑 [DO NOT MERGE] Install ETS packages from source for CI cron jobs 🛑

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,14 @@ before_install:
   - ./travis_ci_bootstrap_edm.sh
   - edm environments create python${RUNTIME} --version ${RUNTIME}
 install:
-  - edm install -e python${RUNTIME} -y future networkx traits traitsui enable numpy pillow mock haas coverage ${TOOLKIT}
+  - edm install -e python${RUNTIME} -y cython networkx pillow swig mock haas coverage ${TOOLKIT}
   # FIXME: pygraphviz should be installed for complete testing
-  - edm run -e python${RUNTIME} -- pip install git+http://github.com/nucleic/kiwi.git#egg=kiwisolver
+  - edm run -e python${RUNTIME} -- pip install git+https://github.com/nucleic/kiwi.git#egg=kiwisolver
+  # Install ETS packages' master branches from source
+  - edm run -e python${RUNTIME} -- pip install --no-deps git+https://github.com/enthought/traits.git
+  - edm run -e python${RUNTIME} -- pip install --no-deps git+https://github.com/enthought/traitsui.git
+  - edm run -e python${RUNTIME} -- pip install --no-deps git+https://github.com/enthought/pyface.git
+  - edm run -e python${RUNTIME} -- pip install --no-deps git+https://github.com/enthought/enable.git
   - edm run -e python${RUNTIME} -- python setup.py develop
 script:
   - edm run -e python${RUNTIME} -- coverage run -m haas -v


### PR DESCRIPTION
This PR is only for checking to make sure the changes work as expected to test Graphcanvas using the current `master` branches of ETS dependencies (_i.e._ `traits`, `traitsui`, `pyface`, and `enable`). Once verified, I'll set up TravisCI to run cron jobs against this branch for up-to-date testing of Graphcanvas versus ETS masters.