### PR TITLE
MAINT: remove `sudo: false` from TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,18 @@ language: generic
 
 matrix:
   include:
-      - env: RUNTIME=2.7 TOOLKIT=pyqt
-      - env: RUNTIME=2.7 TOOLKIT=pyside
-      - env: RUNTIME=3.5 TOOLKIT=pyqt
-      - env: RUNTIME=3.6 TOOLKIT=pyqt
+      - env: RUNTIME=2.7 ETS_TOOLKIT=qt QT_API=pyqt
+      - env: RUNTIME=2.7 ETS_TOOLKIT=qt QT_API=pyside
+      - env: RUNTIME=3.5 ETS_TOOLKIT=qt QT_API=pyqt
+      - env: RUNTIME=3.6 ETS_TOOLKIT=qt QT_API=pyqt
       - os: osx
-        env: RUNTIME=2.7 TOOLKIT=pyqt
+        env: RUNTIME=2.7 ETS_TOOLKIT=qt QT_API=pyqt
       - os: osx
-        env: RUNTIME=2.7 TOOLKIT=pyside
+        env: RUNTIME=2.7 ETS_TOOLKIT=qt QT_API=pyside
       - os: osx
-        env: RUNTIME=3.5 TOOLKIT=pyqt
+        env: RUNTIME=3.5 ETS_TOOLKIT=qt QT_API=pyqt
       - os: osx
-        env: RUNTIME=3.6 TOOLKIT=pyqt
+        env: RUNTIME=3.6 ETS_TOOLKIT=qt QT_API=pyqt
 
 cache:
   pip: true
@@ -27,7 +27,7 @@ before_install:
   - ./travis_ci_bootstrap_edm.sh
   - edm environments create python${RUNTIME} --version ${RUNTIME}
 install:
-  - edm install -e python${RUNTIME} -y future networkx traits traitsui enable numpy pillow mock haas coverage ${TOOLKIT}
+  - edm install -e python${RUNTIME} -y future networkx traits traitsui enable numpy pillow mock haas coverage ${QT_API}
   # FIXME: pygraphviz should be installed for complete testing
   - edm run -e python${RUNTIME} -- pip install git+http://github.com/nucleic/kiwi.git#egg=kiwisolver
   - edm run -e python${RUNTIME} -- python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: generic
-sudo: false
+
 matrix:
   include:
       - env: RUNTIME=2.7 TOOLKIT=pyqt


### PR DESCRIPTION
Per https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration, this PR removes the `sudo: false` entry from the Travis CI configuration, which will cause the Linux CI builds to use Travis' virtual machine-based infrastructure instead of the container-based infrastructure.