### PR TITLE
Disable macOS builds on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,22 +26,6 @@ matrix:
       - env: RUNTIME=3.5 QT_API=pyqt
       - env: RUNTIME=3.6 QT_API=pyqt NX_VERSION=-1.11-7
       - env: RUNTIME=3.6 QT_API=pyqt
-      - os: osx
-        env: RUNTIME=2.7 QT_API=pyqt NX_VERSION=-1.11-7
-      - os: osx
-        env: RUNTIME=2.7 QT_API=pyqt
-      - os: osx
-        env: RUNTIME=2.7 QT_API=pyside NX_VERSION=-1.11-7
-      - os: osx
-        env: RUNTIME=2.7 QT_API=pyside
-      - os: osx
-        env: RUNTIME=3.5 QT_API=pyqt NX_VERSION=-1.11-7
-      - os: osx
-        env: RUNTIME=3.5 QT_API=pyqt
-      - os: osx
-        env: RUNTIME=3.6 QT_API=pyqt NX_VERSION=-1.11-7
-      - os: osx
-        env: RUNTIME=3.6 QT_API=pyqt
 
 cache:
   pip: true
@@ -52,7 +36,6 @@ before_install:
   - mkdir -p "${HOME}/.cache/download"
   - export DISPLAY=:99.0
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; export PLATFORM_TAG="rh6-x86_64"; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; export PLATFORM_TAG="osx-x86_64"; fi
   - echo ${PATH}
   - edm environments create python${RUNTIME} --version ${RUNTIME} --platform ${PLATFORM_TAG}
 install:


### PR DESCRIPTION
macOS minutes are expensive; remove macOS builds from the Travis CI configuration. Longer term, we should plan to migrate to GitHub Actions.