### PR TITLE
Fix cron job

### DIFF
--- a/graphcanvas/graph_container.py
+++ b/graphcanvas/graph_container.py
@@ -267,7 +267,7 @@ class GraphContainer(Container):
                 # Draw the left arrowhead (for an arrow pointing straight up)
                 arrow_ends = (
                     line_ends -
-                    numpy.array(unit_vec * numpy.matrix([[c, s], [-s, c]])) *
+                    numpy.array(unit_vec @ numpy.array([[c, s], [-s, c]])) *
                     10
                 )
                 gc.begin_path()
@@ -277,7 +277,7 @@ class GraphContainer(Container):
                 # Draw the right arrowhead (for an arrow pointing straight up)
                 arrow_ends = (
                     line_ends -
-                    numpy.array(unit_vec * numpy.matrix([[c, -s], [s, c]])) *
+                    numpy.array(unit_vec @ numpy.array([[c, -s], [s, c]])) *
                     10
                 )
                 gc.begin_path()

--- a/graphcanvas/layout.py
+++ b/graphcanvas/layout.py
@@ -48,7 +48,7 @@ def tree_layout(graph, dim=2, scale=1):
 
             # top-down
             draw_depth = 1.0 - float(curr_depth)/max_depth
-            depth_width = float(widths[curr_depth])
+            depth_width = widths[curr_depth]
 
             # center align
             nodes_positioned_at_depth[curr_depth] += 1

--- a/graphcanvas/tests/test_graph_view.py
+++ b/graphcanvas/tests/test_graph_view.py
@@ -47,7 +47,7 @@ class TestGraphView(unittest.TestCase):
     def test_canvas(self):
         self.assertIsInstance(self.view._canvas, DAGContainer)
         tools = self.view._canvas.tools
-        self.assertEquals(len(tools), 3)
+        self.assertEqual(len(tools), 3)
         self.assertIsInstance(tools[0], GraphNodeSelectionTool)
         self.assertIsInstance(tools[1], GraphNodeHoverTool)
 
@@ -64,14 +64,14 @@ class TestGraphView(unittest.TestCase):
         viewport = container.viewport_component
         self.assertIsInstance(viewport, Viewport)
 
-        self.assertEquals(len(viewport.tools), 2)
+        self.assertEqual(len(viewport.tools), 2)
         self.assertIsInstance(viewport.tools[0], ViewportZoomTool)
         self.assertIsInstance(viewport.tools[1], ViewportPanTool)
 
     def test_layout_changed(self):
         new_layout = 'circular'
         self.view.layout = new_layout
-        self.assertEquals(self.view._canvas.style, new_layout)
+        self.assertEqual(self.view._canvas.style, new_layout)
 
     def test_nodes(self):
         expected_nodes = [node for node in self.g.nodes()]

--- a/graphcanvas/tests/test_layout.py
+++ b/graphcanvas/tests/test_layout.py
@@ -53,20 +53,20 @@ class TestLayout(unittest.TestCase):
 
     def test_non_2D(self):
         g = networkx.DiGraph()
-        with self.assertRaisesRegexp(ValueError, 'only 2D graphs'):
+        with self.assertRaisesRegex(ValueError, 'only 2D graphs'):
             tree_layout(g, dim=1)
             tree_layout(g, dim=3)
 
     def test_not_directed(self):
         g = networkx.Graph()
-        with self.assertRaisesRegexp(ValueError, 'directed'):
+        with self.assertRaisesRegex(ValueError, 'directed'):
             tree_layout(g)
 
     def test_not_acyclic(self):
         g = networkx.DiGraph()
         g.add_edge('root', 'child')
         g.add_edge('child', 'root')
-        with self.assertRaisesRegexp(ValueError, 'must not contain cycles'):
+        with self.assertRaisesRegex(ValueError, 'must not contain cycles'):
             tree_layout(g)
 
 


### PR DESCRIPTION
This PR fixes an error seen in the cron job which installs a newer version of `numpy` than the regular development environment installs (1.19 _vs._ 1.17). In numpy 1.19, `np.linspace` raises a `TypeError` when it receives a non-integer third argument (the `num` parameter) which for some reason we are passing a `float` to. This PR just removes the float literal from that argument, which is an int to begin with.

I also addressed a few `DeprecationWarning`s that were being raised to keep things up-to-date.